### PR TITLE
fix: restore base bundle size report

### DIFF
--- a/.github/scripts/update-size-comment.mts
+++ b/.github/scripts/update-size-comment.mts
@@ -26,6 +26,7 @@ const format = (bytes: number) => `${(bytes / 1024).toFixed(2)} kB`;
 const delta = (current: number, previous?: number) => {
   if (previous === undefined || previous === null) return "";
   const difference = current - previous;
+  if (difference === 0) return "-";
   const sign = difference > 0 ? "+" : "";
   const icon = difference > 0 ? " 🔺" : difference < 0 ? " 🎉" : "";
   const percentage = ` (${sign}${((difference / previous) * 100).toFixed(1)}%${icon})`;
@@ -36,11 +37,11 @@ const row = (name: string, key: keyof typeof pr) =>
 const marker = "<!-- radiance-size-report -->";
 const body = [
   marker,
-  "## Bundle size 📦",
-  "minified, gzipped sizes",
+  "### 📦 Bundle size",
+  "_minified and gzipped_",
   "| Bundle | Base | PR | Delta |",
   "| --- | ---: | ---: | ---: |",
-  row("`lib/dist/index.js`", "libraryGzipBytes"),
+  row("`index.js`", "libraryGzipBytes"),
   row("`glCanvas`", "glCanvasGzipBytes"),
 ].join("\n");
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -35,8 +35,16 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v4
         with:
-          path: ${{ runner.temp }}/base-size-report
+          path: ${{ runner.temp }}/size-report
           key: bundle-size-${{ github.event.pull_request.base.sha }}
+
+      - name: Preserve base size report
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -f "${RUNNER_TEMP}/size-report/report.json" ]; then
+            mkdir -p "${RUNNER_TEMP}/base-size-report"
+            cp "${RUNNER_TEMP}/size-report/report.json" "${RUNNER_TEMP}/base-size-report/report.json"
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/lib/package.json
+++ b/lib/package.json
@@ -39,7 +39,6 @@
     "lint:fix": "eslint src --fix",
     "prepack": "tsdown",
     "release": "changelogen --release --clean && pnpm publish",
-    "size": "size-limit",
     "test": "playwright test",
     "test:local": "docker compose run --build --rm -p 9323:9323 test",
     "test:update": "docker compose run --build --rm -p 9323:9323 test sh -c 'xvfb-run pnpm run test -u'",
@@ -49,7 +48,6 @@
     "@arethetypeswrong/core": "0.18.5",
     "@astrojs/check": "0.9.10",
     "@playwright/test": "1.62.1",
-    "@size-limit/preset-small-lib": "13.0.3",
     "@tweakpane/core": "2.0.5",
     "@types/node": "24.13.3",
     "astro": "7.1.6",
@@ -59,7 +57,6 @@
     "gl-matrix": "3.4.4",
     "prettier": "3.9.6",
     "publint": "0.3.22",
-    "size-limit": "13.0.3",
     "tsdown": "0.22.14",
     "tweakpane": "4.0.5",
     "typedoc": "0.28.20",
@@ -73,10 +70,5 @@
     "excludeAuthors": [
       ""
     ]
-  },
-  "size-limit": [
-    {
-      "path": "dist/index.js"
-    }
-  ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
-      '@size-limit/preset-small-lib':
-        specifier: 13.0.3
-        version: 13.0.3(size-limit@13.0.3)
       '@tweakpane/core':
         specifier: 2.0.5
         version: 2.0.5
@@ -130,9 +127,6 @@ importers:
       publint:
         specifier: 0.3.22
         version: 0.3.22
-      size-limit:
-        specifier: 13.0.3
-        version: 13.0.3
       tsdown:
         specifier: 0.22.14
         version: 0.22.14(@arethetypeswrong/core@0.18.5)(@volar/typescript@2.4.28(typescript@6.0.3))(publint@0.3.22)(typescript@6.0.3)
@@ -1624,23 +1618,6 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@size-limit/esbuild@13.0.3':
-    resolution: {integrity: sha512-g24wsTxM3N/SaGv1MiiDjTShNrIna1WCNJ7NXMrlsWBHWv1OL0nCyllR1bDDHf+gV41lF7QxX7vknswoOr71DQ==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      size-limit: 13.0.3
-
-  '@size-limit/file@13.0.3':
-    resolution: {integrity: sha512-PWTITIXH5p9aGIf6qq2Fruihn/b9nBQyfkyoAyb6DzFJgS1Ek9MSPJYKxKFLO8jdo0aqSgBPd3sevbS6PyBiJw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      size-limit: 13.0.3
-
-  '@size-limit/preset-small-lib@13.0.3':
-    resolution: {integrity: sha512-rqKn1+JkVF5ckZRmcxeQPZ8g0e9Fqddh6bjmDotijXJtN40KJQ+5TG6pTiYq3RaA4nkuEkixHULpDBGcgAARAg==}
-    peerDependencies:
-      size-limit: 13.0.3
-
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -2403,10 +2380,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  bytes-iec@3.1.1:
-    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
-    engines: {node: '>= 0.8'}
 
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
@@ -3349,10 +3322,6 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
-
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
@@ -3585,14 +3554,6 @@ packages:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  nanoid@6.0.1:
-    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
-    engines: {node: ^22 || ^24 || >=26}
-    hasBin: true
-
-  nanospinner@1.2.2:
-    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3983,11 +3944,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  size-limit@13.0.3:
-    resolution: {integrity: sha512-KVb2aNEU49BwTR21SVjD+2QHP9gBV/nWsTHzNB/heRwXtHyA7lLQiDZDQ1TiNh/B/TZXKAZrHYyTt+cvBUrzYw==}
-    engines: {node: ^22.18.0 || ^24.0.0 || >=26.0.0}
-    hasBin: true
 
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
@@ -5964,22 +5920,6 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@size-limit/esbuild@13.0.3(size-limit@13.0.3)':
-    dependencies:
-      esbuild: 0.28.1
-      nanoid: 6.0.1
-      size-limit: 13.0.3
-
-  '@size-limit/file@13.0.3(size-limit@13.0.3)':
-    dependencies:
-      size-limit: 13.0.3
-
-  '@size-limit/preset-small-lib@13.0.3(size-limit@13.0.3)':
-    dependencies:
-      '@size-limit/esbuild': 13.0.3(size-limit@13.0.3)
-      '@size-limit/file': 13.0.3(size-limit@13.0.3)
-      size-limit: 13.0.3
-
   '@stitches/core@1.2.8': {}
 
   '@tweakpane/core@2.0.5': {}
@@ -6783,8 +6723,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  bytes-iec@3.1.1: {}
 
   c12@3.3.4(magicast@0.5.4):
     dependencies:
@@ -7736,8 +7674,6 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
-  lilconfig@3.1.3: {}
-
   linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
@@ -8167,12 +8103,6 @@ snapshots:
   muggle-string@0.4.1: {}
 
   nanoid@3.3.17: {}
-
-  nanoid@6.0.1: {}
-
-  nanospinner@1.2.2:
-    dependencies:
-      picocolors: 1.1.1
 
   natural-compare@1.4.0: {}
 
@@ -8655,12 +8585,6 @@ snapshots:
       '@types/hast': 3.0.5
 
   sisteransi@1.0.5: {}
-
-  size-limit@13.0.3:
-    dependencies:
-      bytes-iec: 3.1.1
-      lilconfig: 3.1.3
-      nanospinner: 1.2.2
 
   smol-toml@1.7.1: {}
 


### PR DESCRIPTION
## Summary
- restore the base size cache using the same path used when saving it
- preserve the restored base report before the PR measurement overwrites the working report

## Root cause
GitHub Actions cache identity includes the configured path. The workflow saved to `runner.temp/size-report` but restored to `runner.temp/base-size-report`, so the cache key existed but could not be restored.

## Validation
- `pnpm --dir lib typecheck`
- Node syntax checks for `.github/scripts/*.mts`
- `git diff --check`
- rebased onto `main` with one commit